### PR TITLE
Bugfix: Enemy spawner and missing player reference

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -617,71 +617,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1807780546
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1874990315484048395, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_Name
-      value: Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 2955802740638934769, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_SortingOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5906236051856791112, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: damageTaken
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5.458053
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.6657586
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8607304971326464833, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 11d95817b12e84a4082ed1ed31c29769, type: 3}
 --- !u!1 &1828502756
 GameObject:
   m_ObjectHideFlags: 0
@@ -885,6 +820,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9007521428449226668, guid: 1c5a93d80cf55b44696cd2fb0b7d4049, type: 3}
+      propertyPath: m_Constraints
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -902,7 +841,6 @@ SceneRoots:
   - {fileID: 146734374}
   - {fileID: 1092388853012045804}
   - {fileID: 512755429912449731}
-  - {fileID: 1807780546}
   - {fileID: 1828502757}
   - {fileID: 636936951}
   - {fileID: 1269148361}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -447,7 +447,7 @@ MonoBehaviour:
   player: {fileID: 1092388853012045805}
   spawnInterval: 3
   maxEnemies: 10
-  spawnDistance: 10
+  spawnDistance: 12
   respawnDistance: 40
 --- !u!1001 &884647736
 PrefabInstance:

--- a/Assets/Scripts/ChunkManager.cs
+++ b/Assets/Scripts/ChunkManager.cs
@@ -53,6 +53,11 @@ public class ChunkManager : MonoBehaviour
     // Checks if player moved to different chunk 
     private void Update()
     {
+        if (player == null)
+        {
+            return;
+        }
+
         Vector2Int playerChunk = GetChunkCoordinate(player.position);
         
         if (playerChunk == currentPlayerChunk)

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -7,7 +7,7 @@ public class EnemySpawner : MonoBehaviour
     [SerializeField] private Transform player;
     [SerializeField] private float spawnInterval = 3f;
     [SerializeField] private int maxEnemies = 10; 
-    [SerializeField] private float spawnDistance = 10f; // With current setup, 10f is just outside camera view
+    [SerializeField] private float spawnDistance = 12f; // With current setup, 12f is just outside camera view
     [SerializeField] private float respawnDistance = 40f;
     
     private readonly List<GameObject> activeEnemies = new();
@@ -15,6 +15,11 @@ public class EnemySpawner : MonoBehaviour
     
     private void Update()
     {
+        if (player == null)
+        {
+            return;
+        }
+
         UpdateActiveEnemies();
         
         // TODO: This should gradually increase as the game progresses instead of staying a flat amount
@@ -50,12 +55,20 @@ public class EnemySpawner : MonoBehaviour
         return spawnPosition;
     }
     
-    // Respawns enemies that get farther than the respawnDistance
+    // Removes dead enemies and respawns enemies that get farther than the respawnDistance
     private void UpdateActiveEnemies()
     {
-        foreach (GameObject enemyObject in activeEnemies)
+        for (int i = activeEnemies.Count - 1; i >= 0; i--)
         {
-            if (enemyObject != null && Vector2.Distance(enemyObject.transform.position, player.position) > respawnDistance)
+            GameObject enemyObject = activeEnemies[i];
+
+            if (enemyObject == null)
+            {
+                activeEnemies.RemoveAt(i);
+                continue;
+            }
+
+            if (Vector2.Distance(enemyObject.transform.position, player.position) > respawnDistance)
             {
                 enemyObject.transform.position = GetSpawn();
             }

--- a/Assets/Scripts/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySpawner.cs
@@ -55,7 +55,7 @@ public class EnemySpawner : MonoBehaviour
         return spawnPosition;
     }
     
-    // Removes dead enemies and respawns enemies that get farther than the respawnDistance
+    // Removes destroyed enemy references and moves distant enemies back near the player
     private void UpdateActiveEnemies()
     {
         for (int i = activeEnemies.Count - 1; i >= 0; i--)


### PR DESCRIPTION
## Summary

Small bugfix update for issues relating to `EnemySpawner` and `ChunkManager` that popped up after latest integration. 

- Fixed enemy spawning stopping completely after `maxEnemies` enemies have been destroyed.
  - Enemy spawner now removes destroyed enemies from `activeEnemies`.
  - `maxEnemies` now correctly represents enemies alive instead of enemies spawned over whole run.

- Fixed repeated `MissingReferenceException` errors in console after player death.
  - `EnemySpawner` and `ChunkManager` now stop looking for `player.position` after the player has been killed.

- Increased the default enemy spawn distance from `10` to `12` so enemies do not visibly spawn in the corners of the game view.

- Removed the manually placed enemy from `GameScene` because enemies now come from spawner.

- Froze the player's Z rotation because why is he spinning.